### PR TITLE
Fix divide by zero when original file size is 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Boot task to `gzip` files and nothing else.
 
 [](dependency)
 ```clojure
-[org.martinklepsch/boot-gzip "0.1.2"] ;; latest release
+[org.martinklepsch/boot-gzip "0.1.3"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 
 (require '[adzerk.bootlaces :refer [bootlaces! build-jar push-release]])
 
-(def +version+ "0.1.2")
+(def +version+ "0.1.3")
 
 (bootlaces! +version+)
 

--- a/src/org/martinklepsch/boot_gzip.clj
+++ b/src/org/martinklepsch/boot_gzip.clj
@@ -15,9 +15,11 @@
            (format "%.1f %sB" (/ bytes (Math/pow unit exp)) pre)))))
 
 (defn ^:private percent-saved [old new]
-  (-> (* 100 (/ (- old new) old))
-      float
-      java.lang.Math/round))
+  (if (not= old 0)
+    (-> (* 100 (/ (- old new) old))
+        float
+        java.lang.Math/round)
+    0))
 
 (defn ^:private file-by-path [path fileset]
   (c/tmp-file (get (:tree fileset) path)))


### PR DESCRIPTION
Granted, it doesn't make a whole lot of sense to gzip empty files, but it probably shouldn't throw an error if you do.